### PR TITLE
utils: add get_number_of_author_matches helper

### DIFF
--- a/inspire_matcher/utils.py
+++ b/inspire_matcher/utils.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+from inspire_json_merger.comparators import AuthorComparator
+
+
+def get_number_of_author_matches(x_authors, y_authors):
+    """Return the number of matches between two lists of authors.
+
+    Args:
+        x_authors (list(dict)): a schema-compliant list of authors.
+        y_authors (list(dict)): another schema-compliant list of authors.
+
+    Returns:
+        int: the number of matching authors between the two lists.
+
+    """
+    return len(AuthorComparator(x_authors, y_authors).matches)

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ install_requires = [
     'Werkzeug~=0.0,>=0.12.2',
     'elasticsearch-dsl~=2.0,>=2.2.0',
     'elasticsearch~=2.0,>=2.4.1',
+    'inspire-json-merger~=2.0,>=2.0.0',
     'inspire-utils~=0.0,>=0.0.10',
     'invenio-search>=1.0.0a10',
     'six~=1.0,>=1.11.0',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+from inspire_matcher.utils import get_number_of_author_matches
+
+
+def test_get_number_of_author_matches():
+    x_authors = [
+        {'full_name': 'Cabibbo, Nicola'},
+        {'full_name': 'Kobayashi, Makoto'},
+        {'full_name': 'Maskawa, Toshihide'},
+    ]
+    y_authors = [
+        {'full_name': 'Kobayashi, Makoto'},
+        {'full_name': 'Maskawa, Toshihide'},
+    ]
+
+    expected = 2
+    result = get_number_of_author_matches(x_authors, y_authors)
+
+    assert expected == result


### PR DESCRIPTION
* Adds a helper util method for getting the number of author matches
  given two hep-schema compliant author JSON object lists.

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>

---
The build is going to fail for now. An update of `inspire-json-merger` is expected, to fix a unicode related issue.