### PR TITLE
tests: split app and app_context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,4 +56,3 @@ deploy:
     branch: master
     python: 2.7
   distribution: sdist
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,11 +30,16 @@ from invenio_search import InvenioSearch
 from inspire_matcher import InspireMatcher
 
 
-@pytest.fixture(autouse=True, scope='session')
+@pytest.fixture(scope='session')
 def app():
     app = Flask(__name__)
     InvenioSearch(app)
     InspireMatcher(app)
 
+    yield app
+
+
+@pytest.fixture(autouse=True, scope='function')
+def app_context(app):
     with app.app_context():
         yield app


### PR DESCRIPTION
In this way each test sees a fresh context, but the application is
still being initialized exactly once.