### PR TITLE
core: require a value per path in a nested query

### DIFF
--- a/inspire_matcher/core.py
+++ b/inspire_matcher/core.py
@@ -103,16 +103,13 @@ def _compile_nested(query, record):
     for path, search_path in zip(paths, search_paths):
         value = get_value(record, path)
         if not value:
-            continue
+            return
 
         result['query']['nested']['query']['bool']['must'].append({
             'match': {
                 search_path: value,
             },
         })
-
-    if not result['query']['nested']['query']['bool']['must']:
-        return
 
     return result
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -257,85 +257,17 @@ def test_compile_nested():
     assert expected == result
 
 
-def test_compile_nested_skips_non_existing_paths():
+def test_compile_nested_requires_all_paths_to_contain_a_value_in_order_to_generate_a_query():
     query = {
         'paths': [
             'reference.publication_info.journal_title',
             'reference.publication_info.journal_volume',
-            'reference.publication_info.journal_issue',
             'reference.publication_info.artid',
-            'reference.publication_info.page_start',
-            'reference.publication_info.page_end',
         ],
         'search_paths': [
             'publication_info.journal_title',
             'publication_info.journal_volume',
-            'publication_info.journal_issue',
             'publication_info.artid',
-            'publication_info.page_start',
-            'publication_info.page_end',
-        ],
-    }
-    reference = {
-        'reference': {
-            'publication_info': {
-                'journal_title': 'Phys.Rev.',
-                'journal_volume': 'D94',
-                'artid': '124054',
-            },
-        },
-    }
-
-    expected = {
-        'query': {
-            'nested': {
-                'path': 'publication_info',
-                'query': {
-                    'bool': {
-                        'must': [
-                            {
-                                'match': {
-                                    'publication_info.journal_title': 'Phys.Rev.',
-                                },
-                            },
-                            {
-                                'match': {
-                                    'publication_info.journal_volume': 'D94',
-                                },
-                            },
-                            {
-                                'match': {
-                                    'publication_info.artid': '124054',
-                                },
-                            },
-                        ],
-                    },
-                },
-            },
-        },
-    }
-    result = _compile_nested(query, reference)
-
-    assert expected == result
-
-
-def test_compile_nested_does_not_generate_an_empty_query():
-    query = {
-        'paths': [
-            'reference.publication_info.journal_title',
-            'reference.publication_info.journal_volume',
-            'reference.publication_info.journal_issue',
-            'reference.publication_info.artid',
-            'reference.publication_info.page_start',
-            'reference.publication_info.page_end',
-        ],
-        'search_paths': [
-            'publication_info.journal_title',
-            'publication_info.journal_volume',
-            'publication_info.journal_issue',
-            'publication_info.artid',
-            'publication_info.page_start',
-            'publication_info.page_end',
         ],
     }
     reference = {


### PR DESCRIPTION
Makes so that in order for a nested query to be sent to Elasticsearch
**all** paths contain a value. This is to prevent sending incomplete
queries that result in spurious matches.

CC: @jmartinm 