### PR TITLE
core: add minimum_should_match only when needed

### DIFF
--- a/inspire_matcher/core.py
+++ b/inspire_matcher/core.py
@@ -51,13 +51,13 @@ def _compile_exact(query, record):
     result = {
         'query': {
             'bool': {
-                'minimum_should_match': 1,
                 'should': [],
             },
         },
     }
 
     if collections:
+        result['query']['bool']['minimum_should_match'] = 1
         result['query']['bool']['filter'] = {'bool': {'should': []}}
 
         for collection in collections:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -47,7 +47,6 @@ def test_compile_exact():
     expected = {
         'query': {
             'bool': {
-                'minimum_should_match': 1,
                 'should': [
                     {
                         'match': {
@@ -184,7 +183,6 @@ def test_compile_exact_supports_non_list_fields():
     expected = {
         'query': {
             'bool': {
-                'minimum_should_match': 1,
                 'should': [
                     {
                         'match': {


### PR DESCRIPTION
This field only matters when we have a ``filter``, which only happens
whenever we are filtering by collection.