### PR TITLE
Implement author_titles_validator for the fuzzy matcher

### DIFF
--- a/inspire_matcher/core.py
+++ b/inspire_matcher/core.py
@@ -113,7 +113,7 @@ def _compile_fuzzy(query, record):
         path = path.split('[')[0]
         if '.' in path:
             raise ValueError('the "path" key can\'t contain dots')
-
+        # TODO: This query should be refined instead of relying on validation to filter out irrelevant results.
         result['query']['dis_max']['queries'].append({
             'more_like_this': {
                 'boost': boost,

--- a/inspire_matcher/utils.py
+++ b/inspire_matcher/utils.py
@@ -53,7 +53,10 @@ def compute_authors_jaccard_index(x_authors, y_authors):
     intersection_cardinal = get_number_of_author_matches(x_authors, y_authors)
     union_cardinal = max(len(x_authors), len(y_authors))
 
-    return intersection_cardinal / float(union_cardinal)
+    if union_cardinal:
+        return intersection_cardinal / float(union_cardinal)
+    else:
+        return 0.0
 
 
 def compute_titles_jaccard_index(x_title, y_title):
@@ -73,7 +76,10 @@ def compute_titles_jaccard_index(x_title, y_title):
     intersection_cardinal = len(record_title_tokens & result_title_tokens)
     union_cardinal = len(record_title_tokens | result_title_tokens)
 
-    return intersection_cardinal / float(union_cardinal)
+    if union_cardinal:
+        return intersection_cardinal / float(union_cardinal)
+    else:
+        return 0.0
 
 
 def get_tokenized_title(title):

--- a/inspire_matcher/utils.py
+++ b/inspire_matcher/utils.py
@@ -37,3 +37,55 @@ def get_number_of_author_matches(x_authors, y_authors):
 
     """
     return len(AuthorComparator(x_authors, y_authors).matches)
+
+
+def compute_authors_jaccard_index(x_authors, y_authors):
+    """Return the Jaccard similarity coefficient between 2 author sets.
+
+    Args:
+        x_authors (list(dict)): first schema-compliant list of authors.
+        y_authors (list(dict)): second schema-compliant list of authors.
+
+    Returns:
+        float: Jaccard similarity coefficient between the 2 author sets.
+
+    """
+    intersection_cardinal = get_number_of_author_matches(x_authors, y_authors)
+    union_cardinal = max(len(x_authors), len(y_authors))
+
+    return intersection_cardinal / float(union_cardinal)
+
+
+def compute_titles_jaccard_index(x_title, y_title):
+    """Return the Jaccard similarity coefficient between 2 titles.
+
+    Args:
+        x_title (string): first title.
+        y_title (string): second title.
+
+    Returns:
+        float: Jaccard similarity coefficient between the 2 titles token sets.
+
+    """
+    record_title_tokens = get_tokenized_title(x_title)
+    result_title_tokens = get_tokenized_title(y_title)
+
+    intersection_cardinal = len(record_title_tokens & result_title_tokens)
+    union_cardinal = len(record_title_tokens | result_title_tokens)
+
+    return intersection_cardinal / float(union_cardinal)
+
+
+def get_tokenized_title(title):
+    """Return the tokenised title.
+
+    The title is lowercased and split on the spaces. Then, duplicate tokens are removed by adding the tokens to a set.
+
+    Args:
+        title (string): a titles.
+
+    Returns:
+        set: contains the resulting tokens.
+
+    """
+    return set(title.lower().split())

--- a/inspire_matcher/validators.py
+++ b/inspire_matcher/validators.py
@@ -24,6 +24,52 @@
 
 from __future__ import absolute_import, division, print_function
 
+from itertools import product
+
+from inspire_utils.record import get_value
+
+from .utils import (
+    compute_authors_jaccard_index,
+    compute_titles_jaccard_index,
+)
+
 
 def default_validator(record, result):
     return True
+
+
+def authors_titles_validator(record, possible_match):
+    """Compute a validation score for the possible match.
+
+    The score is based on the Jaccard index of the authors sets and the maximum Jaccard index found between 2 titles from
+    the record and the possible match title sets.
+
+    The default score is 0.5. If the computed score is higher than this, then the match is valid, otherwise it is not.
+
+    Args:
+        record (dict): the given record we are trying to match with similar ones in INSPIRE.
+        possible_match (dict): possible match returned by the ES query that needs to be validated.
+
+    Returns:
+        bool: validation decision.
+
+    """
+    author_score = 0.5
+    record_authors = get_value(record, 'authors', [])
+    result_authors = get_value(possible_match, '_source.authors', [])
+
+    if record_authors and result_authors:
+        author_score = compute_authors_jaccard_index(record_authors, result_authors)
+
+    title_max_score = 0.5
+    record_titles = get_value(record, 'titles.title', [])
+    result_titles = get_value(possible_match, '_source.titles.title', [])
+
+    if record_titles and result_titles:
+        for cartesian_pair in product(record_titles, result_titles):
+            current_title_jaccard = compute_titles_jaccard_index(cartesian_pair[0], cartesian_pair[1])
+
+            if current_title_jaccard > title_max_score:
+                title_max_score = current_title_jaccard
+
+    return (author_score + title_max_score) / 2 > 0.5

--- a/inspire_matcher/validators.py
+++ b/inspire_matcher/validators.py
@@ -59,7 +59,9 @@ def authors_titles_validator(record, possible_match):
     result_authors = get_value(possible_match, '_source.authors', [])
 
     if record_authors and result_authors:
-        author_score = compute_authors_jaccard_index(record_authors, result_authors)
+        record_sample_nr = min(len(record_authors), 5)
+        match_sample_nr = min(len(result_authors), 5)
+        author_score = compute_authors_jaccard_index(record_authors[:record_sample_nr], result_authors[:match_sample_nr])
 
     title_max_score = 0.5
     record_titles = get_value(record, 'titles.title', [])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,7 +22,12 @@
 
 from __future__ import absolute_import, division, print_function
 
-from inspire_matcher.utils import get_number_of_author_matches
+from inspire_matcher.utils import (
+    compute_authors_jaccard_index,
+    compute_titles_jaccard_index,
+    get_number_of_author_matches,
+    get_tokenized_title,
+)
 
 
 def test_get_number_of_author_matches():
@@ -40,3 +45,176 @@ def test_get_number_of_author_matches():
     result = get_number_of_author_matches(x_authors, y_authors)
 
     assert expected == result
+
+
+def test_get_tokenized_title():
+    title = 'Exotic Exotic RG RG Flows from Holography'
+
+    expected = {'exotic', 'rg', 'flows', 'from', 'holography'}
+
+    result = get_tokenized_title(title)
+
+    assert expected == result
+
+
+def test_compute_authors_jaccard_index_perfect_matching_authors():
+    author_list1 = [
+        {
+            'full_name': 'Smith, J.'
+        },
+        {
+            'full_name': 'Zappacosta, L.',
+        },
+        {
+            'full_name': 'Comastri, A.',
+            'name_variations': [
+                'comastri a',
+                'comastri a.',
+                'a comastri',
+                'comastri',
+                'comastri, a',
+                'a. comastri',
+                'comastri, a.',
+                'a, comastri',
+                'a., comastri'
+            ]
+        }
+    ]
+
+    author_list2 = [
+        {
+            'full_name': 'Smith, J.',
+            'signature_block': 'SMITHJO',
+        },
+        {
+            'full_name': 'Zappacosta, L.',
+            'uuid': '2160fa69-9efa-44a9-bbe9-2121a8bd52e4'
+        },
+        {
+            'full_name': 'Comastri, A.',
+        }
+    ]
+
+    result = compute_authors_jaccard_index(author_list1, author_list2)
+
+    assert result == 1.0
+
+
+def test_compute_authors_jaccard_index_no_author_match():
+    author_list1 = [
+        {
+            'full_name': 'Smith, J.'
+        },
+        {
+            'full_name': 'Zappacosta, L.',
+        },
+        {
+            'full_name': 'Black, S.',
+            'signature_block': 'BLACKS',
+        },
+        {
+            'full_name': 'Comastri, A.',
+            'name_variations': [
+                'comastri a',
+                'comastri a.',
+                'a comastri',
+                'comastri',
+                'comastri, a',
+                'a. comastri',
+                'comastri, a.',
+                'a, comastri',
+                'a., comastri'
+            ]
+        }
+    ]
+
+    author_list2 = [
+        {
+            'full_name': 'Roberts, A.',
+        }
+    ]
+
+    result = compute_authors_jaccard_index(author_list1, author_list2)
+
+    assert result == 0.0
+
+
+def test_compute_authors_jaccard_index_half_authors_match():
+    author_list1 = [
+        {
+            'full_name': 'Smith, J.'
+        },
+        {
+            'full_name': 'Zappacosta, L.',
+        },
+        {
+            'full_name': 'Black, S.',
+            'signature_block': 'BLACKS',
+        },
+        {
+            'full_name': 'Comastri, A.',
+            'name_variations': [
+                'comastri a',
+                'comastri a.',
+                'a comastri',
+                'comastri',
+                'comastri, a',
+                'a. comastri',
+                'comastri, a.',
+                'a, comastri',
+                'a., comastri'
+            ]
+        }
+    ]
+
+    author_list2 = [
+        {
+            'full_name': 'Smith, J.',
+            'signature_block': 'SMITHJO',
+        },
+        {
+            'full_name': 'Zappacosta, L.',
+            'name_variations': [
+                'zappacosta l',
+                'zappacosta l.',
+                'l zappacosta',
+                'zappacosta',
+                'zappacosta, l',
+                'l. zappacosta',
+                'zappacosta, l.',
+                'l, zappacosta',
+                'l., zappacosta'
+            ]
+        },
+    ]
+
+    result = compute_authors_jaccard_index(author_list1, author_list2)
+
+    assert result == 0.5
+
+
+def test_compute_titles_jaccard_index_perfect_matching_titles():
+    title1 = 'CP VIOLATION IN THE B SYSTEM'
+    title2 = 'cp violation in the b system'
+
+    result = compute_titles_jaccard_index(title1, title2)
+
+    assert result == 1.0
+
+
+def test_compute_titles_jaccard_index_different_titles():
+    title1 = 'PYTHIA 6.4 Physics and Manual'
+    title2 = 'cp violation in the b system'
+
+    result = compute_titles_jaccard_index(title1, title2)
+
+    assert result == 0.0
+
+
+def test_compute_titles_jaccard_index_similar_titles():
+    title1 = 'CP violation B'
+    title2 = 'CP violation in the B system'
+
+    result = compute_titles_jaccard_index(title1, title2)
+
+    assert result == 0.5

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -32,7 +32,70 @@ def test_default_validator_is_not_very_exciting():
     assert default_validator(None, None)
 
 
-def test_authors_titles_validator_authors_only_passes():
+def test_authors_titles_validator_authors_only_passes_first_five_many_match():
+    record = {
+        '_collections': ['Literature'],
+        'document_type': ['article'],
+        'authors': [
+            {
+                'full_name': 'Smith, J.'
+            },
+            {
+                'full_name': 'Zappacosta, L.',
+            },
+            {
+                'full_name': 'Comastri, A.',
+            }
+
+        ]
+    }
+
+    result = {
+        '_source': {
+            '_collections': ['Literature'],
+            'document_type': ['article'],
+            'authors': [
+                {
+                    'full_name': 'Smith, J.'
+                },
+                {
+                    'full_name': 'Zappacosta, L.',
+                },
+                {
+                    'full_name': 'Comastri, A.',
+                },
+                {
+                    'full_name': 'Masini, A.'
+                },
+                {
+                    'full_name': 'Civano, F.'
+                },
+                {
+                    'full_name': 'Fornasini, F.'
+                },
+                {
+                    'full_name': 'Treister, E.'
+                },
+                {
+                    'full_name': 'Alexander, A.'
+                },
+                {
+                    'full_name': 'Boorman, P.G.'
+                },
+                {
+                    'full_name': 'Brandt, D.'
+                },
+                {
+                    'full_name': 'Lanz, L.'
+                }
+            ]
+        }
+    }  # Jaccard index > 0.5 for first 5 authors
+
+    assert authors_titles_validator(record, result)
+
+
+def test_authors_titles_validator_authors_only_fails_first_five_few_match():
     record = {
         '_collections': ['Literature'],
         'document_type': ['article'],
@@ -42,60 +105,6 @@ def test_authors_titles_validator_authors_only_passes():
             },
             {
                 'full_name': 'Comastri, A.',
-                'full_name_unicode_normalized': 'comastri, a.',
-                'inspire_roles': [
-                    'author'
-                ]
-            }
-
-        ]
-    }
-
-    result = {
-        '_source': {
-            '_collections': ['Literature'],
-            'document_type': ['article'],
-            'authors': [
-                {
-                    'full_name': 'Smith, J.'
-                },
-                {
-                    'full_name': 'Zappacosta, L.',
-                    'signature_block': 'ZAPACASTl',
-                    'uuid': '2160fa69-9efa-44a9-bbe9-2121a8bd52e4'
-                },
-                {
-                    'full_name': 'Comastri, A.',
-                    'name_variations': [
-                        'comastri a',
-                        'comastri a.',
-                        'a comastri',
-                        'comastri',
-                        'comastri, a',
-                        'a. comastri',
-                        'comastri, a.',
-                        'a, comastri',
-                        'a., comastri'
-                    ]
-                }
-            ]
-        }
-    }  # Jaccard index > 0.5
-
-    assert authors_titles_validator(record, result)
-
-
-def test_authors_titles_validator_authors_only_fails():
-    record = {
-        '_collections': ['Literature'],
-        'document_type': ['article'],
-        'authors': [
-            {
-                'full_name': 'Comastri, A.',
-                'full_name_unicode_normalized': 'comastri, a.',
-                'inspire_roles': [
-                    'author'
-                ]
             }
         ]
     }
@@ -110,26 +119,37 @@ def test_authors_titles_validator_authors_only_fails():
                 },
                 {
                     'full_name': 'Zappacosta, L.',
-                    'signature_block': 'ZAPACASTl',
-                    'uuid': '2160fa69-9efa-44a9-bbe9-2121a8bd52e4'
                 },
                 {
                     'full_name': 'Comastri, A.',
-                    'name_variations': [
-                        'comastri a',
-                        'comastri a.',
-                        'a comastri',
-                        'comastri',
-                        'comastri, a',
-                        'a. comastri',
-                        'comastri, a.',
-                        'a, comastri',
-                        'a., comastri'
-                    ]
+                },
+                {
+                    'full_name': 'Masini, A.'
+                },
+                {
+                    'full_name': 'Civano, F.'
+                },
+                {
+                    'full_name': 'Fornasini, F.'
+                },
+                {
+                    'full_name': 'Treister, E.'
+                },
+                {
+                    'full_name': 'Alexander, A.'
+                },
+                {
+                    'full_name': 'Boorman, P.G.'
+                },
+                {
+                    'full_name': 'Brandt, D.'
+                },
+                {
+                    'full_name': 'Lanz, L.'
                 }
             ]
         }
-    }  # Jaccard index < 0.5
+    }  # Jaccard index < 0.5 for first 5 authors
 
     assert not authors_titles_validator(record, result)
 
@@ -140,12 +160,9 @@ def test_authors_titles_validator_titles_only_passes_exact_match():
         'document_type': ['article'],
         'titles': [
             {
-                'source': 'submitter',
                 'title': 'A MATCHING TITLE',  # Jaccard index == 1.0
-                'subtitle': 'a subtitle'
             },
             {
-                'source': 'submitter',
                 'title': 'CMB anisotropies: A Decadal survey'
             }
         ]
@@ -160,22 +177,16 @@ def test_authors_titles_validator_titles_only_passes_exact_match():
                     'title': 'a matching title'
                 },
                 {
-                    'source': 'submitter',
-                    'title': 'Exotic RG Flows from Holography',
-
+                    'title': 'Exotic RG Flows from Holography'
                 },
                 {
-                    'title': 'CP violation in the B system',
-                    'subtitle': 'a subtitle '
+                    'title': 'CP violation in the B system'
                 },
                 {
-                    'source': 'submitter',
-                    'title': 'Supersymmetry',
-                    'subtitle': 'a subtitle 4'
+                    'title': 'Supersymmetry'
                 },
                 {
-                    'source': 'submitter',
-                    'title': 'PYTHIA 6.4 Physics and Manual',
+                    'title': 'PYTHIA 6.4 Physics and Manual'
                 }
             ]
         }
@@ -190,12 +201,9 @@ def test_authors_titles_validator_titles_only_passes_partial_match():
         'document_type': ['article'],
         'titles': [
             {
-                'source': 'submitter',
-                'title': 'A PARTIAL MATCHING TITLE ONLY',  # 0.5 < Jaccard index < 1.0
-                'subtitle': 'a subtitle'
+                'title': 'A PARTIAL MATCHING TITLE ONLY'  # 0.5 < Jaccard index < 1.0
             },
             {
-                'source': 'submitter',
                 'title': 'CMB anisotropies: A Decadal survey'
             }
         ]
@@ -210,22 +218,17 @@ def test_authors_titles_validator_titles_only_passes_partial_match():
                     'title': 'a matching title'
                 },
                 {
-                    'source': 'submitter',
-                    'title': 'Exotic RG Flows from Holography',
+                    'title': 'Exotic RG Flows from Holography'
 
                 },
                 {
-                    'title': 'CP violation in the B system',
-                    'subtitle': 'a subtitle '
+                    'title': 'CP violation in the B system'
                 },
                 {
-                    'source': 'submitter',
-                    'title': 'Supersymmetry',
-                    'subtitle': 'a subtitle 4'
+                    'title': 'Supersymmetry'
                 },
                 {
-                    'source': 'submitter',
-                    'title': 'PYTHIA 6.4 Physics and Manual',
+                    'title': 'PYTHIA 6.4 Physics and Manual'
                 }
             ]
         }
@@ -321,23 +324,10 @@ def test_authors_titles_validator_passes_authors_and_titles_match_authors():
                 'full_name': 'Smith, J.'
             },
             {
-                'full_name': 'Zappacosta, L.',
-                'signature_block': 'ZAPACASTl',
-                'uuid': '2160fa69-9efa-44a9-bbe9-2121a8bd52e4'
+                'full_name': 'Zappacosta, L.'
             },
             {
-                'full_name': 'Comastri, A.',
-                'name_variations': [
-                    'comastri a',
-                    'comastri a.',
-                    'a comastri',
-                    'comastri',
-                    'comastri, a',
-                    'a. comastri',
-                    'comastri, a.',
-                    'a, comastri',
-                    'a., comastri'
-                ]
+                'full_name': 'Comastri, A.'
             }
         ],
         'titles': [
@@ -356,9 +346,7 @@ def test_authors_titles_validator_passes_authors_and_titles_match_authors():
                     'full_name': 'Smith, J.'
                 },
                 {
-                    'full_name': 'Zappacosta, L.',
-                    'signature_block': 'ZAPACASTl',
-                    'uuid': '2160fa69-9efa-44a9-bbe9-2121a8bd52e4'
+                    'full_name': 'Zappacosta, L.'
                 },
 
             ],
@@ -392,23 +380,10 @@ def test_authors_titles_validator_passes_authors_and_titles_match_both():
                 'full_name': 'Smith, J.'
             },
             {
-                'full_name': 'Zappacosta, L.',
-                'signature_block': 'ZAPACASTl',
-                'uuid': '2160fa69-9efa-44a9-bbe9-2121a8bd52e4'
+                'full_name': 'Zappacosta, L.'
             },
             {
-                'full_name': 'Comastri, A.',
-                'name_variations': [
-                    'comastri a',
-                    'comastri a.',
-                    'a comastri',
-                    'comastri',
-                    'comastri, a',
-                    'a. comastri',
-                    'comastri, a.',
-                    'a, comastri',
-                    'a., comastri'
-                ]
+                'full_name': 'Comastri, A.'
             }
         ],
         'titles': [
@@ -430,9 +405,7 @@ def test_authors_titles_validator_passes_authors_and_titles_match_both():
                     'full_name': 'Smith, J.'
                 },
                 {
-                    'full_name': 'Zappacosta, L.',
-                    'signature_block': 'ZAPACASTl',
-                    'uuid': '2160fa69-9efa-44a9-bbe9-2121a8bd52e4'
+                    'full_name': 'Zappacosta, L.'
                 },
 
             ],
@@ -441,17 +414,17 @@ def test_authors_titles_validator_passes_authors_and_titles_match_both():
                     'title': 'a good matching title'
                 },
                 {
-                    'title': 'Exotic RG Flows from Holography',
+                    'title': 'Exotic RG Flows from Holography'
 
                 },
                 {
-                    'title': 'CP violation in the B system',
+                    'title': 'CP violation in the B system'
                 },
                 {
-                    'title': 'Supersymmetry',
+                    'title': 'Supersymmetry'
                 },
                 {
-                    'title': 'PYTHIA 6.4 Physics and Manual',
+                    'title': 'PYTHIA 6.4 Physics and Manual'
                 }
             ]
         }
@@ -469,23 +442,10 @@ def test_authors_titles_validator_fails_authors_and_titles_match_author():
                 'full_name': 'Smith, J.'
             },
             {
-                'full_name': 'Zappacosta, L.',
-                'signature_block': 'ZAPACASTl',
-                'uuid': '2160fa69-9efa-44a9-bbe9-2121a8bd52e4'
+                'full_name': 'Zappacosta, L.'
             },
             {
-                'full_name': 'Comastri, A.',
-                'name_variations': [
-                    'comastri a',
-                    'comastri a.',
-                    'a comastri',
-                    'comastri',
-                    'comastri, a',
-                    'a. comastri',
-                    'comastri, a.',
-                    'a, comastri',
-                    'a., comastri'
-                ]
+                'full_name': 'Comastri, A.'
             }
         ],
         'titles': [
@@ -504,9 +464,7 @@ def test_authors_titles_validator_fails_authors_and_titles_match_author():
                     'full_name': 'Smith, J.'
                 },
                 {
-                    'full_name': 'Black, J.',
-                    'signature_block': 'BLACKJO',
-                    'uuid': '2160fa69-9rfa-44a9-bba8-2121a8bd52e4'
+                    'full_name': 'Black, J.'
                 },
 
             ],
@@ -540,23 +498,10 @@ def test_authors_titles_validator_fails_authors_and_titles_match_title_but_not_a
                 'full_name': 'Bentley, M.'
             },
             {
-                'full_name': 'Zappacosta, L.',
-                'signature_block': 'ZAPACASTl',
-                'uuid': '2160fa69-9efa-44a9-bbe9-2121a8bd52e4'
+                'full_name': 'Zappacosta, L.'
             },
             {
-                'full_name': 'Comastri, A.',
-                'name_variations': [
-                    'comastri a',
-                    'comastri a.',
-                    'a comastri',
-                    'comastri',
-                    'comastri, a',
-                    'a. comastri',
-                    'comastri, a.',
-                    'a, comastri',
-                    'a., comastri'
-                ]
+                'full_name': 'Comastri, A.'
             }
         ],
         'titles': [
@@ -578,9 +523,7 @@ def test_authors_titles_validator_fails_authors_and_titles_match_title_but_not_a
                     'full_name': 'Smith, J.'
                 },
                 {
-                    'full_name': 'Black, J.',
-                    'signature_block': 'BLACKJO',
-                    'uuid': '2160fa69-9rfa-44a9-bba8-2121a8bd52e4'
+                    'full_name': 'Black, J.'
                 },
 
             ],
@@ -617,23 +560,10 @@ def test_authors_titles_validator_fails_authors_and_titles_partial_match_title()
                 'full_name': 'Bentley, M.'
             },
             {
-                'full_name': 'Zappacosta, L.',
-                'signature_block': 'ZAPACASTl',
-                'uuid': '2160fa69-9efa-44a9-bbe9-2121a8bd52e4'
+                'full_name': 'Zappacosta, L.'
             },
             {
-                'full_name': 'Comastri, A.',
-                'name_variations': [
-                    'comastri a',
-                    'comastri a.',
-                    'a comastri',
-                    'comastri',
-                    'comastri, a',
-                    'a. comastri',
-                    'comastri, a.',
-                    'a, comastri',
-                    'a., comastri'
-                ]
+                'full_name': 'Comastri, A.'
             }
         ],
         'titles': [
@@ -655,9 +585,7 @@ def test_authors_titles_validator_fails_authors_and_titles_partial_match_title()
                     'full_name': 'Smith, J.'
                 },
                 {
-                    'full_name': 'Black, J.',
-                    'signature_block': 'BLACKJO',
-                    'uuid': '2160fa69-9rfa-44a9-bba8-2121a8bd52e4'
+                    'full_name': 'Black, J.'
                 },
 
             ],
@@ -694,23 +622,10 @@ def test_authors_titles_validator_fails_authors_and_titles_partial_match_both():
                 'full_name': 'Smith, J.'
             },
             {
-                'full_name': 'Zappacosta, L.',
-                'signature_block': 'ZAPACASTl',
-                'uuid': '2160fa69-9efa-44a9-bbe9-2121a8bd52e4'
+                'full_name': 'Zappacosta, L.'
             },
             {
-                'full_name': 'Comastri, A.',
-                'name_variations': [
-                    'comastri a',
-                    'comastri a.',
-                    'a comastri',
-                    'comastri',
-                    'comastri, a',
-                    'a. comastri',
-                    'comastri, a.',
-                    'a, comastri',
-                    'a., comastri'
-                ]
+                'full_name': 'Comastri, A.'
             }
         ],
         'titles': [
@@ -732,9 +647,7 @@ def test_authors_titles_validator_fails_authors_and_titles_partial_match_both():
                     'full_name': 'Smith, J.'
                 },
                 {
-                    'full_name': 'Black, J.',
-                    'signature_block': 'BLACKJO',
-                    'uuid': '2160fa69-9rfa-44a9-bba8-2121a8bd52e4'
+                    'full_name': 'Black, J.'
                 },
 
             ],
@@ -776,23 +689,10 @@ def test_authors_titles_validator_fails_authors_and_titles_no_match_both():
                 'full_name': 'Smith, J.'
             },
             {
-                'full_name': 'Zappacosta, L.',
-                'signature_block': 'ZAPACASTl',
-                'uuid': '2160fa69-9efa-44a9-bbe9-2121a8bd52e4'
+                'full_name': 'Zappacosta, L.'
             },
             {
-                'full_name': 'Comastri, A.',
-                'name_variations': [
-                    'comastri a',
-                    'comastri a.',
-                    'a comastri',
-                    'comastri',
-                    'comastri, a',
-                    'a. comastri',
-                    'comastri, a.',
-                    'a, comastri',
-                    'a., comastri'
-                ]
+                'full_name': 'Comastri, A.'
             }
         ]
     }
@@ -806,9 +706,7 @@ def test_authors_titles_validator_fails_authors_and_titles_no_match_both():
                     'full_name': 'Bentley, M.'
                 },
                 {
-                    'full_name': 'Black, J.',
-                    'signature_block': 'BLACKJO',
-                    'uuid': '2160fa69-9rfa-44a9-bba8-2121a8bd52e4'
+                    'full_name': 'Black, J.'
                 }
             ],
             'titles': [

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -22,8 +22,811 @@
 
 from __future__ import absolute_import, division, print_function
 
-from inspire_matcher.validators import default_validator
+from inspire_matcher.validators import (
+    authors_titles_validator,
+    default_validator,
+)
 
 
 def test_default_validator_is_not_very_exciting():
     assert default_validator(None, None)
+
+
+def test_authors_titles_validator_authors_only_passes():
+    record = {
+        '_collections': ['Literature'],
+        'document_type': ['article'],
+        'authors': [
+            {
+                'full_name': 'Smith, J.'
+            },
+            {
+                'full_name': 'Comastri, A.',
+                'full_name_unicode_normalized': 'comastri, a.',
+                'inspire_roles': [
+                    'author'
+                ]
+            }
+
+        ]
+    }
+
+    result = {
+        '_source': {
+            '_collections': ['Literature'],
+            'document_type': ['article'],
+            'authors': [
+                {
+                    'full_name': 'Smith, J.'
+                },
+                {
+                    'full_name': 'Zappacosta, L.',
+                    'signature_block': 'ZAPACASTl',
+                    'uuid': '2160fa69-9efa-44a9-bbe9-2121a8bd52e4'
+                },
+                {
+                    'full_name': 'Comastri, A.',
+                    'name_variations': [
+                        'comastri a',
+                        'comastri a.',
+                        'a comastri',
+                        'comastri',
+                        'comastri, a',
+                        'a. comastri',
+                        'comastri, a.',
+                        'a, comastri',
+                        'a., comastri'
+                    ]
+                }
+            ]
+        }
+    }  # Jaccard index > 0.5
+
+    assert authors_titles_validator(record, result)
+
+
+def test_authors_titles_validator_authors_only_fails():
+    record = {
+        '_collections': ['Literature'],
+        'document_type': ['article'],
+        'authors': [
+            {
+                'full_name': 'Comastri, A.',
+                'full_name_unicode_normalized': 'comastri, a.',
+                'inspire_roles': [
+                    'author'
+                ]
+            }
+        ]
+    }
+
+    result = {
+        '_source': {
+            '_collections': ['Literature'],
+            'document_type': ['article'],
+            'authors': [
+                {
+                    'full_name': 'Smith, J.'
+                },
+                {
+                    'full_name': 'Zappacosta, L.',
+                    'signature_block': 'ZAPACASTl',
+                    'uuid': '2160fa69-9efa-44a9-bbe9-2121a8bd52e4'
+                },
+                {
+                    'full_name': 'Comastri, A.',
+                    'name_variations': [
+                        'comastri a',
+                        'comastri a.',
+                        'a comastri',
+                        'comastri',
+                        'comastri, a',
+                        'a. comastri',
+                        'comastri, a.',
+                        'a, comastri',
+                        'a., comastri'
+                    ]
+                }
+            ]
+        }
+    }  # Jaccard index < 0.5
+
+    assert not authors_titles_validator(record, result)
+
+
+def test_authors_titles_validator_titles_only_passes_exact_match():
+    record = {
+        '_collections': ['Literature'],
+        'document_type': ['article'],
+        'titles': [
+            {
+                'source': 'submitter',
+                'title': 'A MATCHING TITLE',  # Jaccard index == 1.0
+                'subtitle': 'a subtitle'
+            },
+            {
+                'source': 'submitter',
+                'title': 'CMB anisotropies: A Decadal survey'
+            }
+        ]
+    }
+
+    result = {
+        '_source': {
+            '_collections': ['Literature'],
+            'document_type': ['article'],
+            'titles': [
+                {
+                    'title': 'a matching title'
+                },
+                {
+                    'source': 'submitter',
+                    'title': 'Exotic RG Flows from Holography',
+
+                },
+                {
+                    'title': 'CP violation in the B system',
+                    'subtitle': 'a subtitle '
+                },
+                {
+                    'source': 'submitter',
+                    'title': 'Supersymmetry',
+                    'subtitle': 'a subtitle 4'
+                },
+                {
+                    'source': 'submitter',
+                    'title': 'PYTHIA 6.4 Physics and Manual',
+                }
+            ]
+        }
+    }
+
+    assert authors_titles_validator(record, result)
+
+
+def test_authors_titles_validator_titles_only_passes_partial_match():
+    record = {
+        '_collections': ['Literature'],
+        'document_type': ['article'],
+        'titles': [
+            {
+                'source': 'submitter',
+                'title': 'A PARTIAL MATCHING TITLE ONLY',  # 0.5 < Jaccard index < 1.0
+                'subtitle': 'a subtitle'
+            },
+            {
+                'source': 'submitter',
+                'title': 'CMB anisotropies: A Decadal survey'
+            }
+        ]
+    }
+
+    result = {
+        '_source': {
+            '_collections': ['Literature'],
+            'document_type': ['article'],
+            'titles': [
+                {
+                    'title': 'a matching title'
+                },
+                {
+                    'source': 'submitter',
+                    'title': 'Exotic RG Flows from Holography',
+
+                },
+                {
+                    'title': 'CP violation in the B system',
+                    'subtitle': 'a subtitle '
+                },
+                {
+                    'source': 'submitter',
+                    'title': 'Supersymmetry',
+                    'subtitle': 'a subtitle 4'
+                },
+                {
+                    'source': 'submitter',
+                    'title': 'PYTHIA 6.4 Physics and Manual',
+                }
+            ]
+        }
+    }
+
+    assert authors_titles_validator(record, result)
+
+
+def test_authors_titles_validator_titles_only_fails_no_match():
+    record = {
+        '_collections': ['Literature'],
+        'document_type': ['article'],
+        'titles': [
+            {
+                'title': 'CMB anisotropies: A Decadal survey'  # Jaccard index == 0.0.
+            }
+        ]
+    }
+
+    result = {
+        '_source': {
+            '_collections': ['Literature'],
+            'document_type': ['article'],
+            'titles': [
+                {
+                    'title': 'Exotic RG Flows from Holography',
+
+                },
+                {
+                    'title': 'CP violation in the B system',
+                },
+                {
+                    'title': 'Supersymmetry',
+                },
+                {
+                    'title': 'PYTHIA 6.4 Physics and Manual',
+                }
+            ]
+        }
+    }
+
+    assert not authors_titles_validator(record, result)
+
+
+def test_authors_titles_validator_titles_only_fails_partial_match():
+    record = {
+        '_collections': ['Literature'],
+        'document_type': ['article'],
+        'titles': [
+            {
+                'title': 'CMB anisotropies: A Decadal survey'
+            },
+            {
+                'title': 'partial matching title but not enough'  # 0.0 < Jaccard index < 0.5
+            }
+        ]
+    }
+
+    result = {
+        '_source': {
+            '_collections': ['Literature'],
+            'document_type': ['article'],
+            'titles': [
+                {
+                    'title': 'partial matching title'
+                },
+                {
+                    'title': 'Exotic RG Flows from Holography',
+
+                },
+                {
+                    'title': 'CP violation in the B system',
+                },
+                {
+                    'title': 'Supersymmetry',
+                },
+                {
+                    'title': 'PYTHIA 6.4 Physics and Manual',
+                }
+            ]
+        }
+    }
+
+    assert not authors_titles_validator(record, result)
+
+
+def test_authors_titles_validator_passes_authors_and_titles_match_authors():
+    record = {
+        '_collections': ['Literature'],
+        'document_type': ['article'],
+        'authors': [
+            {
+                'full_name': 'Smith, J.'
+            },
+            {
+                'full_name': 'Zappacosta, L.',
+                'signature_block': 'ZAPACASTl',
+                'uuid': '2160fa69-9efa-44a9-bbe9-2121a8bd52e4'
+            },
+            {
+                'full_name': 'Comastri, A.',
+                'name_variations': [
+                    'comastri a',
+                    'comastri a.',
+                    'a comastri',
+                    'comastri',
+                    'comastri, a',
+                    'a. comastri',
+                    'comastri, a.',
+                    'a, comastri',
+                    'a., comastri'
+                ]
+            }
+        ],
+        'titles': [
+            {
+                'title': 'CMB anisotropies: A Decadal survey'
+            }
+        ],
+    }
+
+    result = {
+        '_source': {
+            '_collections': ['Literature'],
+            'document_type': ['article'],
+            'authors': [
+                {
+                    'full_name': 'Smith, J.'
+                },
+                {
+                    'full_name': 'Zappacosta, L.',
+                    'signature_block': 'ZAPACASTl',
+                    'uuid': '2160fa69-9efa-44a9-bbe9-2121a8bd52e4'
+                },
+
+            ],
+            'titles': [
+                {
+                    'title': 'Exotic RG Flows from Holography',
+
+                },
+                {
+                    'title': 'CP violation in the B system',
+                },
+                {
+                    'title': 'Supersymmetry',
+                },
+                {
+                    'title': 'PYTHIA 6.4 Physics and Manual',
+                }
+            ]
+        }
+    }
+
+    assert authors_titles_validator(record, result)
+
+
+def test_authors_titles_validator_passes_authors_and_titles_match_both():
+    record = {
+        '_collections': ['Literature'],
+        'document_type': ['article'],
+        'authors': [
+            {
+                'full_name': 'Smith, J.'
+            },
+            {
+                'full_name': 'Zappacosta, L.',
+                'signature_block': 'ZAPACASTl',
+                'uuid': '2160fa69-9efa-44a9-bbe9-2121a8bd52e4'
+            },
+            {
+                'full_name': 'Comastri, A.',
+                'name_variations': [
+                    'comastri a',
+                    'comastri a.',
+                    'a comastri',
+                    'comastri',
+                    'comastri, a',
+                    'a. comastri',
+                    'comastri, a.',
+                    'a, comastri',
+                    'a., comastri'
+                ]
+            }
+        ],
+        'titles': [
+            {
+                'title': 'A MATCHING TITLE'  # 0.0 < Jaccard index < 0.5
+            },
+            {
+                'title': 'CMB anisotropies: A Decadal survey'
+            }
+        ],
+    }
+
+    result = {
+        '_source': {
+            '_collections': ['Literature'],
+            'document_type': ['article'],
+            'authors': [
+                {
+                    'full_name': 'Smith, J.'
+                },
+                {
+                    'full_name': 'Zappacosta, L.',
+                    'signature_block': 'ZAPACASTl',
+                    'uuid': '2160fa69-9efa-44a9-bbe9-2121a8bd52e4'
+                },
+
+            ],
+            'titles': [
+                {
+                    'title': 'a good matching title'
+                },
+                {
+                    'title': 'Exotic RG Flows from Holography',
+
+                },
+                {
+                    'title': 'CP violation in the B system',
+                },
+                {
+                    'title': 'Supersymmetry',
+                },
+                {
+                    'title': 'PYTHIA 6.4 Physics and Manual',
+                }
+            ]
+        }
+    }
+
+    assert authors_titles_validator(record, result)
+
+
+def test_authors_titles_validator_fails_authors_and_titles_match_author():
+    record = {
+        '_collections': ['Literature'],
+        'document_type': ['article'],
+        'authors': [
+            {
+                'full_name': 'Smith, J.'
+            },
+            {
+                'full_name': 'Zappacosta, L.',
+                'signature_block': 'ZAPACASTl',
+                'uuid': '2160fa69-9efa-44a9-bbe9-2121a8bd52e4'
+            },
+            {
+                'full_name': 'Comastri, A.',
+                'name_variations': [
+                    'comastri a',
+                    'comastri a.',
+                    'a comastri',
+                    'comastri',
+                    'comastri, a',
+                    'a. comastri',
+                    'comastri, a.',
+                    'a, comastri',
+                    'a., comastri'
+                ]
+            }
+        ],
+        'titles': [
+            {
+                'title': 'CMB anisotropies: A Decadal survey'
+            }
+        ],
+    }
+
+    result = {
+        '_source': {
+            '_collections': ['Literature'],
+            'document_type': ['article'],
+            'authors': [
+                {
+                    'full_name': 'Smith, J.'
+                },
+                {
+                    'full_name': 'Black, J.',
+                    'signature_block': 'BLACKJO',
+                    'uuid': '2160fa69-9rfa-44a9-bba8-2121a8bd52e4'
+                },
+
+            ],
+            'titles': [
+                {
+                    'title': 'Exotic RG Flows from Holography',
+
+                },
+                {
+                    'title': 'CP violation in the B system',
+                },
+                {
+                    'title': 'Supersymmetry',
+                },
+                {
+                    'title': 'PYTHIA 6.4 Physics and Manual',
+                }
+            ]
+        }
+    }
+
+    assert not authors_titles_validator(record, result)
+
+
+def test_authors_titles_validator_fails_authors_and_titles_match_title_but_not_authors():
+    record = {
+        '_collections': ['Literature'],
+        'document_type': ['article'],
+        'authors': [
+            {
+                'full_name': 'Bentley, M.'
+            },
+            {
+                'full_name': 'Zappacosta, L.',
+                'signature_block': 'ZAPACASTl',
+                'uuid': '2160fa69-9efa-44a9-bbe9-2121a8bd52e4'
+            },
+            {
+                'full_name': 'Comastri, A.',
+                'name_variations': [
+                    'comastri a',
+                    'comastri a.',
+                    'a comastri',
+                    'comastri',
+                    'comastri, a',
+                    'a. comastri',
+                    'comastri, a.',
+                    'a, comastri',
+                    'a., comastri'
+                ]
+            }
+        ],
+        'titles': [
+            {
+                'title': 'A MATCHING TITLE'  # 0.0 < Jaccard index < 0.5
+            },
+            {
+                'title': 'CMB anisotropies: A Decadal survey'
+            }
+        ],
+    }
+
+    result = {
+        '_source': {
+            '_collections': ['Literature'],
+            'document_type': ['article'],
+            'authors': [
+                {
+                    'full_name': 'Smith, J.'
+                },
+                {
+                    'full_name': 'Black, J.',
+                    'signature_block': 'BLACKJO',
+                    'uuid': '2160fa69-9rfa-44a9-bba8-2121a8bd52e4'
+                },
+
+            ],
+            'titles': [
+                {
+                    'title': 'a matching title'  # 0.0 < Jaccard index < 0.5
+                },
+                {
+                    'title': 'Exotic RG Flows from Holography',
+
+                },
+                {
+                    'title': 'CP violation in the B system',
+                },
+                {
+                    'title': 'Supersymmetry',
+                },
+                {
+                    'title': 'PYTHIA 6.4 Physics and Manual',
+                }
+            ]
+        }
+    }
+
+    assert not authors_titles_validator(record, result)
+
+
+def test_authors_titles_validator_fails_authors_and_titles_partial_match_title():
+    record = {
+        '_collections': ['Literature'],
+        'document_type': ['article'],
+        'authors': [
+            {
+                'full_name': 'Bentley, M.'
+            },
+            {
+                'full_name': 'Zappacosta, L.',
+                'signature_block': 'ZAPACASTl',
+                'uuid': '2160fa69-9efa-44a9-bbe9-2121a8bd52e4'
+            },
+            {
+                'full_name': 'Comastri, A.',
+                'name_variations': [
+                    'comastri a',
+                    'comastri a.',
+                    'a comastri',
+                    'comastri',
+                    'comastri, a',
+                    'a. comastri',
+                    'comastri, a.',
+                    'a, comastri',
+                    'a., comastri'
+                ]
+            }
+        ],
+        'titles': [
+            {
+                'title': 'partial matching title but not enough'  # 0.0 < Jaccard index < 0.5
+            },
+            {
+                'title': 'CMB anisotropies: A Decadal survey'
+            }
+        ],
+    }
+
+    result = {
+        '_source': {
+            '_collections': ['Literature'],
+            'document_type': ['article'],
+            'authors': [
+                {
+                    'full_name': 'Smith, J.'
+                },
+                {
+                    'full_name': 'Black, J.',
+                    'signature_block': 'BLACKJO',
+                    'uuid': '2160fa69-9rfa-44a9-bba8-2121a8bd52e4'
+                },
+
+            ],
+            'titles': [
+                {
+                    'title': 'partial matching title'  # 0.0 < Jaccard index < 0.5
+                },
+                {
+                    'title': 'Exotic RG Flows from Holography',
+
+                },
+                {
+                    'title': 'CP violation in the B system',
+                },
+                {
+                    'title': 'Supersymmetry',
+                },
+                {
+                    'title': 'PYTHIA 6.4 Physics and Manual',
+                }
+            ]
+        }
+    }
+
+    assert not authors_titles_validator(record, result)
+
+
+def test_authors_titles_validator_fails_authors_and_titles_partial_match_both():
+    record = {
+        '_collections': ['Literature'],
+        'document_type': ['article'],
+        'authors': [
+            {
+                'full_name': 'Smith, J.'
+            },
+            {
+                'full_name': 'Zappacosta, L.',
+                'signature_block': 'ZAPACASTl',
+                'uuid': '2160fa69-9efa-44a9-bbe9-2121a8bd52e4'
+            },
+            {
+                'full_name': 'Comastri, A.',
+                'name_variations': [
+                    'comastri a',
+                    'comastri a.',
+                    'a comastri',
+                    'comastri',
+                    'comastri, a',
+                    'a. comastri',
+                    'comastri, a.',
+                    'a, comastri',
+                    'a., comastri'
+                ]
+            }
+        ],
+        'titles': [
+            {
+                'title': 'partial matching title but not enough'  # 0.0 < Jaccard index < 0.5
+            },
+            {
+                'title': 'CMB anisotropies: A Decadal survey'
+            }
+        ],
+    }
+
+    result = {
+        '_source': {
+            '_collections': ['Literature'],
+            'document_type': ['article'],
+            'authors': [
+                {
+                    'full_name': 'Smith, J.'
+                },
+                {
+                    'full_name': 'Black, J.',
+                    'signature_block': 'BLACKJO',
+                    'uuid': '2160fa69-9rfa-44a9-bba8-2121a8bd52e4'
+                },
+
+            ],
+            'titles': [
+                {
+                    'title': 'partial matching title'
+                },
+                {
+                    'title': 'Exotic RG Flows from Holography',
+
+                },
+                {
+                    'title': 'CP violation in the B system',
+                },
+                {
+                    'title': 'Supersymmetry',
+                },
+                {
+                    'title': 'PYTHIA 6.4 Physics and Manual',
+                }
+            ]
+        }
+    }
+
+    assert not authors_titles_validator(record, result)
+
+
+def test_authors_titles_validator_fails_authors_and_titles_no_match_both():
+    record = {
+        '_collections': ['Literature'],
+        'document_type': ['article'],
+        'titles': [
+            {
+                'title': 'CMB anisotropies: A Decadal survey'
+            }
+        ],
+        'authors': [
+            {
+                'full_name': 'Smith, J.'
+            },
+            {
+                'full_name': 'Zappacosta, L.',
+                'signature_block': 'ZAPACASTl',
+                'uuid': '2160fa69-9efa-44a9-bbe9-2121a8bd52e4'
+            },
+            {
+                'full_name': 'Comastri, A.',
+                'name_variations': [
+                    'comastri a',
+                    'comastri a.',
+                    'a comastri',
+                    'comastri',
+                    'comastri, a',
+                    'a. comastri',
+                    'comastri, a.',
+                    'a, comastri',
+                    'a., comastri'
+                ]
+            }
+        ]
+    }
+
+    result = {
+        '_source': {
+            '_collections': ['Literature'],
+            'document_type': ['article'],
+            'authors': [
+                {
+                    'full_name': 'Bentley, M.'
+                },
+                {
+                    'full_name': 'Black, J.',
+                    'signature_block': 'BLACKJO',
+                    'uuid': '2160fa69-9rfa-44a9-bba8-2121a8bd52e4'
+                }
+            ],
+            'titles': [
+                {
+                    'title': 'Exotic RG Flows from Holography',
+
+                },
+                {
+                    'title': 'CP violation in the B system',
+                },
+                {
+                    'title': 'Supersymmetry',
+                },
+                {
+                    'title': 'PYTHIA 6.4 Physics and Manual',
+                }
+            ]
+        }
+    }
+
+    assert not authors_titles_validator(record, result)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Implement `author_titles_validator` for the fuzzy matcher with tests and needed utils. It computes a validation score for the possible match. The score is based on the Jaccard index of the authors sets and the maximum Jaccard index found between 2 titles from the record and the possible match title sets. The default score is 0.5. If the computed score is higher than this, then the match is valid, otherwise it is not.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The ES query generated by the fuzzy matcher matches too many irrelevant records. These need to be filtered by authors and titles. The authors check has a higher weight as a records authors are rather stable.

## Related PR
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/inspirehep/inspire-next/pull/3277

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Signed-off-by: Iuliana Voinea <iuliana.voinea@student.manchester.ac.uk>