### PR TITLE
Handle collections and deleted

### DIFF
--- a/inspire_matcher/api.py
+++ b/inspire_matcher/api.py
@@ -63,6 +63,7 @@ def match(record, config=None):
         raise KeyError('Malformed configuration: %s.' % repr(e))
 
     source = config.get('source', [])
+    match_deleted = config.get('match_deleted', False)
     collections = config.get('collections')
     if not (collections is None or (
             isinstance(collections, (list, tuple)) and
@@ -80,7 +81,7 @@ def match(record, config=None):
 
         for j, query in enumerate(queries):
             try:
-                body = compile(query, record, collections=collections)
+                body = compile(query, record, collections=collections, match_deleted=match_deleted)
             except Exception as e:
                 raise ValueError('Malformed query. Query %d of step %d does not compile: %s.' % (j, i, repr(e)))
 

--- a/inspire_matcher/core.py
+++ b/inspire_matcher/core.py
@@ -29,15 +29,15 @@ from inspire_utils.helpers import force_list
 from inspire_utils.record import get_value
 
 
-def compile(query, record, collections=None):
+def compile(query, record, collections=None, match_deleted=False):
     result = _compile_inner(query, record)
-    result = _compile_filters(result, collections)
+    result = _compile_filters(result, collections, match_deleted)
 
     return result
 
 
-def _compile_filters(query, collections):
-    if not collections:
+def _compile_filters(query, collections, match_deleted):
+    if match_deleted and not collections:
         return query
 
     result = {
@@ -51,7 +51,14 @@ def _compile_filters(query, collections):
         },
     }
 
-    result['query']['bool']['filter']['bool']['should'] = _compile_collections(collections)
+    if collections:
+        result['query']['bool']['filter']['bool']['should'] = _compile_collections(collections)
+    if not match_deleted:
+        result['query']['bool']['filter']['bool']['must_not'] = {
+            'match': {
+                'deleted': True,
+            },
+        }
 
     return result
 

--- a/inspire_matcher/core.py
+++ b/inspire_matcher/core.py
@@ -29,7 +29,34 @@ from inspire_utils.helpers import force_list
 from inspire_utils.record import get_value
 
 
-def compile(query, record):
+def compile(query, record, collections=None):
+    result = _compile_inner(query, record)
+    result = _compile_filters(result, collections)
+
+    return result
+
+
+def _compile_filters(query, collections):
+    if not collections:
+        return query
+
+    result = {
+        'query': {
+            'bool': {
+                'must': query['query'],
+                'filter': {
+                    'bool': {},
+                },
+            },
+        },
+    }
+
+    result['query']['bool']['filter']['bool']['should'] = _compile_collections(collections)
+
+    return result
+
+
+def _compile_inner(query, record):
     type_ = query['type']
 
     if type_ == 'exact':
@@ -40,6 +67,14 @@ def compile(query, record):
         return _compile_nested(query, record)
 
     raise NotImplementedError(type_)
+
+
+def _compile_collections(collections):
+    return [{
+        'match': {
+            '_collections': collection,
+        },
+    } for collection in collections]
 
 
 def _compile_exact(query, record):
@@ -53,8 +88,6 @@ def _compile_exact(query, record):
 
     path, search_path = query['path'], query['search_path']
 
-    collections = query.get('collections', [])
-
     values = force_list(get_value(record, path))
     if not values:
         return
@@ -66,17 +99,6 @@ def _compile_exact(query, record):
             },
         },
     }
-
-    if collections:
-        result['query']['bool']['minimum_should_match'] = 1
-        result['query']['bool']['filter'] = {'bool': {'should': []}}
-
-        for collection in collections:
-            result['query']['bool']['filter']['bool']['should'].append({
-                'match': {
-                    '_collections': collection,
-                },
-            })
 
     for value in values:
         result['query']['bool']['should'].append({

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -30,7 +30,7 @@ from inspire_matcher.api import match
 
 def test_match_raises_if_the_configuration_does_not_have_all_the_keys():
     config = {
-        'doc_type': 'records',
+        'doc_type': 'hep',
         'index': 'records-hep',
     }
 
@@ -44,7 +44,7 @@ def test_match_raises_if_one_step_of_the_algorithm_has_no_queries():
         'algorithm': [
             {'validator': 'inspire_matcher.validators:default_validator'},
         ],
-        'doc_type': 'records',
+        'doc_type': 'hep',
         'index': 'records-hep',
     }
 
@@ -78,7 +78,7 @@ def test_match_uses_the_given_validator_callable(es_mock):
                 'validator': dummy_validator,
             },
         ],
-        'doc_type': 'records',
+        'doc_type': 'hep',
         'index': 'records-hep',
     }
 
@@ -101,7 +101,7 @@ def test_match_raises_if_one_query_does_not_have_a_type():
                 ],
             },
         ],
-        'doc_type': 'records',
+        'doc_type': 'hep',
         'index': 'records-hep',
     }
 
@@ -119,7 +119,7 @@ def test_match_raises_if_one_query_type_is_not_supported():
                 ],
             },
         ],
-        'doc_type': 'records',
+        'doc_type': 'hep',
         'index': 'records-hep',
     }
 
@@ -140,10 +140,33 @@ def test_match_raises_if_an_exact_query_does_not_have_all_the_keys():
                 ],
             },
         ],
-        'doc_type': 'records',
+        'doc_type': 'hep',
         'index': 'records-hep',
     }
 
     with pytest.raises(ValueError) as excinfo:
         list(match(None, config))
     assert 'Malformed query' in str(excinfo.value)
+
+
+def test_match_raises_on_invalid_collections():
+    config = {
+        'algorithm': [
+            {
+                'queries': [
+                    {
+                        'search_path': 'arxiv_eprints.value.raw',
+                        'path': 'arxiv_eprints.value',
+                        'type': 'exact',
+                    },
+                ],
+            },
+        ],
+        'doc_type': 'hep',
+        'index': 'records-hep',
+        'collections': 'Literature',
+    }
+
+    with pytest.raises(ValueError) as excinfo:
+        list(match(None, config))
+    assert 'Malformed collections' in str(excinfo.value)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -414,6 +414,47 @@ def test_compile_without_optional_args():
     expected = {
         'query': {
             'bool': {
+                'must': {
+                    'bool': {
+                        'should': [{
+                            'match': {
+                                'dummy.search.path': 'foo',
+                            },
+                        }],
+                    },
+                },
+                'filter': {
+                    'bool': {
+                        'must_not': {
+                            'match': {
+                                'deleted': True,
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    assert expected == result
+
+
+def test_compile_with_match_deleted():
+    query = {
+        'type': 'exact',
+        'path': 'dummy.path',
+        'search_path': 'dummy.search.path',
+    }
+    record = {
+        'dummy': {
+            'path': 'foo',
+        },
+    }
+
+    result = compile(query, record, match_deleted=True)
+    expected = {
+        'query': {
+            'bool': {
                 'should': [{
                     'match': {
                         'dummy.search.path': 'foo',
@@ -465,6 +506,11 @@ def test_compile_with_collections():
                                 },
                             }
                         ],
+                        'must_not': {
+                            'match': {
+                                'deleted': True,
+                            },
+                        },
                     },
                 },
             },

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -28,6 +28,7 @@ from inspire_matcher.core import (
     _compile_exact,
     _compile_fuzzy,
     _compile_nested,
+    compile,
 )
 
 
@@ -51,112 +52,6 @@ def test_compile_exact():
     expected = {
         'query': {
             'bool': {
-                'should': [
-                    {
-                        'match': {
-                            'arxiv_eprints.value.raw': 'hep-th/9711200',
-                        },
-                    },
-                ],
-            },
-        },
-    }
-    result = _compile_exact(query, record)
-
-    assert expected == result
-
-
-def test_compile_exact_supports_a_collection():
-    query = {
-        'collections': [
-            'HAL Hidden',
-        ],
-        'path': 'arxiv_eprints.value',
-        'search_path': 'arxiv_eprints.value.raw',
-        'type': 'exact',
-    }
-    record = {
-        'arxiv_eprints': [
-            {
-                'categories': [
-                    'hep-th',
-                ],
-                'value': 'hep-th/9711200',
-            },
-        ],
-    }
-
-    expected = {
-        'query': {
-            'bool': {
-                'minimum_should_match': 1,
-                'filter': {
-                    'bool': {
-                        'should': [
-                            {
-                                'match': {
-                                    '_collections': 'HAL Hidden',
-                                },
-                            },
-                        ],
-                    },
-                },
-                'should': [
-                    {
-                        'match': {
-                            'arxiv_eprints.value.raw': 'hep-th/9711200',
-                        },
-                    },
-                ],
-            },
-        },
-    }
-    result = _compile_exact(query, record)
-
-    assert expected == result
-
-
-def test_compile_exact_supports_multiple_collections():
-    query = {
-        'collections': [
-            'CDS Hidden',
-            'HAL Hidden',
-        ],
-        'path': 'arxiv_eprints.value',
-        'search_path': 'arxiv_eprints.value.raw',
-        'type': 'exact',
-    }
-    record = {
-        'arxiv_eprints': [
-            {
-                'categories': [
-                    'hep-th',
-                ],
-                'value': 'hep-th/9711200',
-            },
-        ],
-    }
-
-    expected = {
-        'query': {
-            'bool': {
-                'minimum_should_match': 1,
-                'filter': {
-                    'bool': {
-                        'should': [
-                            {
-                                'match': {
-                                    '_collections': 'CDS Hidden',
-                                },
-                            },
-                            {
-                                'match': {
-                                    '_collections': 'HAL Hidden',
-                                },
-                            },
-                        ],
-                    },
-                },
                 'should': [
                     {
                         'match': {
@@ -501,3 +396,79 @@ def test_compile_nested_raises_when_paths_and_search_paths_dont_have_the_same_le
     with pytest.raises(ValueError) as excinfo:
         _compile_nested(query, None)
     assert 'same length' in str(excinfo.value)
+
+
+def test_compile_without_optional_args():
+    query = {
+        'type': 'exact',
+        'path': 'dummy.path',
+        'search_path': 'dummy.search.path',
+    }
+    record = {
+        'dummy': {
+            'path': 'foo',
+        },
+    }
+
+    result = compile(query, record)
+    expected = {
+        'query': {
+            'bool': {
+                'should': [{
+                    'match': {
+                        'dummy.search.path': 'foo',
+                    },
+                }],
+            },
+        },
+    }
+
+    assert expected == result
+
+
+def test_compile_with_collections():
+    query = {
+        'type': 'exact',
+        'path': 'dummy.path',
+        'search_path': 'dummy.search.path',
+    }
+    record = {
+        'dummy': {
+            'path': 'foo',
+        },
+    }
+
+    result = compile(query, record, collections=['Literature', 'HAL Hidden'])
+    expected = {
+        'query': {
+            'bool': {
+                'must': {
+                    'bool': {
+                        'should': [{
+                            'match': {
+                                'dummy.search.path': 'foo',
+                            },
+                        }],
+                    },
+                },
+                'filter': {
+                    'bool': {
+                        'should': [
+                            {
+                                'match': {
+                                    '_collections': 'Literature',
+                                },
+                            },
+                            {
+                                'match': {
+                                    '_collections': 'HAL Hidden',
+                                },
+                            }
+                        ],
+                    },
+                },
+            },
+        },
+    }
+
+    assert expected == result


### PR DESCRIPTION
This adds global handling of two options, in two respective commits:
* `collections`, which optionally specifies collections to restrict the search to
* `match_deleted`, which is `False` by default, and filters out deleted records

This also removes the handling of `collections` in the `exact` algorithm, as they are now handled as a global option.

Both features were tested locally inside `inspire-next` to make sure they emit valid queries and the results are as expected.