### PR TITLE
core: correctly handle empty queries

### DIFF
--- a/inspire_matcher/core.py
+++ b/inspire_matcher/core.py
@@ -37,6 +37,9 @@ def compile(query, record, collections=None, match_deleted=False):
 
 
 def _compile_filters(query, collections, match_deleted):
+    if not query:
+        return None
+
     if match_deleted and not collections:
         return query
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -518,3 +518,14 @@ def test_compile_with_collections():
     }
 
     assert expected == result
+
+
+def test_compile_returns_none_if_empty_inner():
+    query = {
+        'type': 'exact',
+        'path': 'dummy.path',
+        'search_path': 'dummy.search.path',
+    }
+    record = {}
+
+    assert compile(query, record) is None


### PR DESCRIPTION
Previously, if the inner query was empty and filters needed to be added,
an exception was triggered. This commit fixes it by checking whether the
inner query is non-empty before adding the filters.

Signed-off-by: Micha Moskovic <michamos@gmail.com>